### PR TITLE
Histogram concatenation for a faster HistogramTransformer

### DIFF
--- a/qunfold/tests/__init__.py
+++ b/qunfold/tests/__init__.py
@@ -179,6 +179,7 @@ class TestHistogramTransformer(TestCase):
     f = qunfold.HistogramTransformer(10, unit_scale=False)
     self.assertTrue(np.all(f.fit_transform(X, y)[0] == fX))
     self.assertTrue(np.all(f.transform(X) == fX))
+    self.assertTrue(np.all(f.transform(X, average=True) == fX.mean(axis=0)))
 
     # test unit_scale=True, the new default
     self.assertTrue(np.all(f.transform(X).sum(axis=1) == X.shape[1]))

--- a/qunfold/tests/performance_HDx.py
+++ b/qunfold/tests/performance_HDx.py
@@ -19,7 +19,7 @@ def _jax_transform_Xj(Xj, e, n_samples, n_bins):
   ).todense()
 
 class NaivelyAveragedHistogramTransformer(HistogramTransformer):
-  """This implementation of the HistogramTransformer is based on JAX's JIT capabilities."""
+  """This variant of the HistogramTransformer implements average=True as fX.mean()."""
   def _transform_after_preprocessor(self, X, average=False):
     fX = super()._transform_after_preprocessor(X, average=False)
     if average:

--- a/qunfold/transformers.py
+++ b/qunfold/transformers.py
@@ -139,8 +139,21 @@ class HistogramTransformer(AbstractTransformer):
     return self._transform_after_preprocessor(X, average=average)
   def _transform_after_preprocessor(self, X, average=False):
     if not average:
-        return super()._transform_after_preprocessor(X) # FIXME
-    # TODO: return concatenation of numpy histograms
+        fX = []
+        for j in range(X.shape[1]): # feature index
+          e = self.edges[j]
+          i_row = np.arange(X.shape[0])
+          i_col = np.clip(np.ceil((X[:,j] - e[0]) / (e[1]-e[0])).astype(int), 0, self.n_bins-1)
+          fX_j = csr_matrix(
+            (np.ones(X.shape[0], dtype=int), (i_row, i_col)),
+            shape = (X.shape[0], self.n_bins),
+          )
+          fX.append(fX_j.toarray())
+        fX = np.stack(fX).swapaxes(0, 1).reshape((X.shape[0], -1))
+        if self.unit_scale:
+          fX = fX / fX.sum(axis=1, keepdims=True)
+        return fX
+    # return concatenation of numpy histograms
     histograms = []
     for j in range(X.shape[1]):  # feature index
         hist, _ = np.histogram(X[:, j], bins=self.n_bins)

--- a/qunfold/transformers.py
+++ b/qunfold/transformers.py
@@ -133,22 +133,19 @@ class HistogramTransformer(AbstractTransformer):
       e = np.histogram_bin_edges(x, bins=self.n_bins)[1:]
       self.edges.append(e)
     return self._transform_after_preprocessor(X), y
-  def transform(self, X):
+  def transform(self, X, average=False):
     if self.preprocessor is not None:
       X = self.preprocessor.transform(X)
-    return self._transform_after_preprocessor(X)
-  def _transform_after_preprocessor(self, X):
-    fX = []
-    for j in range(X.shape[1]): # feature index
-      e = self.edges[j]
-      i_row = np.arange(X.shape[0])
-      i_col = np.clip(np.ceil((X[:,j] - e[0]) / (e[1]-e[0])).astype(int), 0, self.n_bins-1)
-      fX_j = csr_matrix(
-        (np.ones(X.shape[0], dtype=int), (i_row, i_col)),
-        shape = (X.shape[0], self.n_bins),
-      )
-      fX.append(fX_j.toarray())
-    fX = np.stack(fX).swapaxes(0, 1).reshape((X.shape[0], -1))
-    if self.unit_scale:
-      fX = fX / fX.sum(axis=1, keepdims=True)
-    return fX
+    return self._transform_after_preprocessor(X, average=average)
+  def _transform_after_preprocessor(self, X, average=False):
+    if not average:
+        return super()._transform_after_preprocessor(X) # FIXME
+    # TODO: return concatenation of numpy histograms
+    histograms = []
+    for j in range(X.shape[1]):  # feature index
+        hist, _ = np.histogram(X[:, j], bins=self.n_bins)
+        if self.unit_scale: 
+            histograms.append(hist/(X.shape[1]*X.shape[0]))
+        else:
+            histograms.append(hist/(X.shape[0]))
+    return np.concatenate(histograms)

--- a/qunfold/transformers.py
+++ b/qunfold/transformers.py
@@ -130,7 +130,7 @@ class HistogramTransformer(AbstractTransformer):
       self.n_classes = len(np.unique(y))
     self.edges = []
     for x in X.T: # iterate over columns = features
-      e = np.histogram_bin_edges(x, bins=self.n_bins)[1:]
+      e = np.histogram_bin_edges(x, bins=self.n_bins)
       self.edges.append(e)
     return self._transform_after_preprocessor(X), y
   def transform(self, X, average=False):
@@ -141,7 +141,7 @@ class HistogramTransformer(AbstractTransformer):
     if not average:
         fX = []
         for j in range(X.shape[1]): # feature index
-          e = self.edges[j]
+          e = self.edges[j][1:]
           i_row = np.arange(X.shape[0])
           i_col = np.clip(np.ceil((X[:,j] - e[0]) / (e[1]-e[0])).astype(int), 0, self.n_bins-1)
           fX_j = csr_matrix(
@@ -155,8 +155,13 @@ class HistogramTransformer(AbstractTransformer):
         return fX
     # return concatenation of numpy histograms
     histograms = []
+  
     for j in range(X.shape[1]):  # feature index
-        hist, _ = np.histogram(X[:, j], bins=self.n_bins)
+        e= np.copy(self.edges[j])
+        e[0]=-np.inf
+        e[-1]=np.inf
+        
+        hist, _ = np.histogram(X[:, j], bins=e)
         if self.unit_scale: 
             histograms.append(hist/(X.shape[1]*X.shape[0]))
         else:


### PR DESCRIPTION
Experiment with transform(X, average=True) to produce a mean embedding directly, instead of per-example embeddings, thus opening an opportunity of relying more heavily on numpy's speed.