### PR TITLE
adapting qunfold for the new interface of quapy 

### DIFF
--- a/qunfold/quapy.py
+++ b/qunfold/quapy.py
@@ -1,39 +1,45 @@
 import inspect
-from collections import defaultdict
 from dataclasses import dataclass
 from quapy.method.base import BaseQuantifier
-from . import AbstractMethod, LinearMethod
+from . import AbstractMethod
 from .base import BaseMixin
 
+
 @dataclass
-class QuaPyWrapper(BaseQuantifier,BaseMixin):
-  """A thin wrapper for using qunfold methods in QuaPy.
+class QuaPyWrapper(BaseQuantifier, BaseMixin):
+    """A thin wrapper for using qunfold methods in QuaPy.
 
-  Args:
-    _method: An instance of `qunfold.methods.AbstractMethod` to wrap.
+    Args:
+      _method: An instance of `qunfold.methods.AbstractMethod` to wrap.
 
-  Examples:
-    Here, we wrap an instance of ACC to perform a grid search with QuaPy.
+    Examples:
+      Here, we wrap an instance of ACC to perform a grid search with QuaPy.
 
-      >>> qunfold_method = QuaPyWrapper(ACC(RandomForestClassifier(obb_score=True)))
-      >>> quapy.model_selection.GridSearchQ(
-      >>>     model = qunfold_method,
-      >>>     param_grid = { # try both splitting criteria
-      >>>         "representation__classifier__estimator__criterion": ["gini", "entropy"],
-      >>>     },
-      >>>     # ...
-      >>> )
-  """
-  _method: AbstractMethod
-  def fit(self, data): # data is a qp.LabelledCollection
-    self._method.fit(*data.Xy, data.n_classes)
-    return self
-  def quantify(self, X):
-    return self._method.predict(X)
-  def set_params(self, **params):
-    self._method.set_params(**params)
-    return self
-  def get_params(self, deep=True):
-    return self._method.get_params(deep)
-  def __str__(self):
-    return self._method.__str__()
+        >>> qunfold_method = QuaPyWrapper(ACC(RandomForestClassifier(obb_score=True)))
+        >>> quapy.model_selection.GridSearchQ(
+        >>>     model = qunfold_method,
+        >>>     param_grid = { # try both splitting criteria
+        >>>         "representation__classifier__estimator__criterion": ["gini", "entropy"],
+        >>>     },
+        >>>     # ...
+        >>> )
+    """
+    _method: AbstractMethod
+
+    def fit(self, X, y):
+        self._method.fit(X, y, n_classes=len(set(y)))
+        return self
+
+    def predict(self, X):
+        return self._method.predict(X)
+
+    def set_params(self, **params):
+        self._method.set_params(**params)
+        return self
+
+    def get_params(self, deep=True):
+        return self._method.get_params(deep)
+
+    def __str__(self):
+        return self._method.__str__()
+


### PR DESCRIPTION
Hi Mirko,

I'm working on a new version of QuaPy where I've (finally!) removed the cumbersome dependency between LabelledCollection and the quantification methods. The class still exists, but now all quantifiers are trained using:

```python
quantifier.fit(X, y)
```

I've also added a predict method (the old quantify method still works as an alias for the nostalgic).

This PR updates the QuaPy wrapper accordingly. I have not modified the version number of qunfold, assuming you'd prefer to handle versioning yourself.

Let me know if anything needs changing!

Best,
Alex