### PR TITLE
sample_weight implementation for non-kernel-based representations

### DIFF
--- a/qunfold/methods/linear/representations.py
+++ b/qunfold/methods/linear/representations.py
@@ -410,7 +410,7 @@ class OriginalRepresentation(AbstractRepresentation):
     self.p_trn = class_prevalences(y, n_classes)
     if not average:
       return X, y
-    M = np.array([ X[y==c].average(axis=0, weights=sample_weight) for c in range(len(self.p_trn)) ]).T # = M
+    M = np.array([ X[y==c].average(axis=0, weights=sample_weight[y==c]) for c in range(len(self.p_trn)) ]).T # = M
     return M
   def transform(self, X, sample_weight=None, average=True):
     n_classes = len(self.p_trn)

--- a/qunfold/tests/__init__.py
+++ b/qunfold/tests/__init__.py
@@ -10,6 +10,7 @@ from sklearn.ensemble import RandomForestClassifier
 from sklearn.linear_model import LogisticRegression
 from unittest import TestCase
 from qunfold import HDx, HellingerSurrogateLoss
+import unittest
 
 RNG = np.random.RandomState(876) # make tests reproducible
 
@@ -302,3 +303,27 @@ class TestHellingerSurrogateLoss(TestCase):
       self.assertAlmostEqual(F_hl + new_loss(p_tst),
                              0.5 * old_loss(p_tst),
                              places=5)
+
+class TestRepresentationsUnitScale(TestCase):
+  """TODO: Implement tests for unit scaling"""
+  def test_unit_scale(self):
+    q, M, p_trn = make_problem()
+    n_classes = len(p_trn)
+    X_trn, y_trn = generate_data(M, p_trn)
+    p_tst = RNG.permutation(p_trn)
+    X_tst, y_tst = generate_data(M, p_tst)
+
+    forest = RandomForestClassifier(oob_score=True)
+    repr_class = qunfold.ClassRepresentation(
+      classifier=forest,
+      is_probabilistic=False,
+      fit_classifier=True,
+      unit_scale=True
+    )
+    
+    M_est = repr_class.fit_transform(X_trn, y_trn, n_classes)
+    q_tst = repr_class.transform(X_tst)
+
+
+if __name__ == '__main__':
+  unittest.main()     

--- a/qunfold/tests/__init__.py
+++ b/qunfold/tests/__init__.py
@@ -10,7 +10,6 @@ from sklearn.ensemble import RandomForestClassifier
 from sklearn.linear_model import LogisticRegression
 from unittest import TestCase
 from qunfold import HDx, HellingerSurrogateLoss
-import unittest
 
 RNG = np.random.RandomState(876) # make tests reproducible
 
@@ -302,28 +301,4 @@ class TestHellingerSurrogateLoss(TestCase):
       # check for 6 decimal place accuracy
       self.assertAlmostEqual(F_hl + new_loss(p_tst),
                              0.5 * old_loss(p_tst),
-                             places=5)
-
-class TestRepresentationsUnitScale(TestCase):
-  """TODO: Implement tests for unit scaling"""
-  def test_unit_scale(self):
-    q, M, p_trn = make_problem()
-    n_classes = len(p_trn)
-    X_trn, y_trn = generate_data(M, p_trn)
-    p_tst = RNG.permutation(p_trn)
-    X_tst, y_tst = generate_data(M, p_tst)
-
-    forest = RandomForestClassifier(oob_score=True)
-    repr_class = qunfold.ClassRepresentation(
-      classifier=forest,
-      is_probabilistic=False,
-      fit_classifier=True,
-      unit_scale=True
-    )
-    
-    M_est = repr_class.fit_transform(X_trn, y_trn, n_classes)
-    q_tst = repr_class.transform(X_tst)
-
-
-if __name__ == '__main__':
-  unittest.main()     
+                             places=5)    


### PR DESCRIPTION
#### Added **sample_weight** as an optional parameter to all representations that do not use a kernel function: 
- Most Methods use this parameter to calculate weighted averages.
- The **HistogramRepresentation** aggregates the weights of the samples  instead of the count in the corresponding bin.  
- All Kernel Representations throw a **ValueError** if sample weights are provided.